### PR TITLE
Refactor dynamic filters to generate more efficient code

### DIFF
--- a/lib/ecto/generic_queries.ex
+++ b/lib/ecto/generic_queries.ex
@@ -32,6 +32,10 @@ defmodule PhoenixApiToolkit.Ecto.GenericQueries do
   alias Ecto.Query
   require Ecto.Query
 
+  @typedoc "The directions supported by `order_by/4`"
+  @type order_directions ::
+          :asc | :asc_nulls_first | :asc_nulls_last | :desc | :desc_nulls_first | :desc_nulls_last
+
   @doc """
   Narrow down the query to results in which the value contained in
   `binding.field` is smaller than `value`.
@@ -104,12 +108,7 @@ defmodule PhoenixApiToolkit.Ecto.GenericQueries do
       iex> order_by(base_query(), :user, :name, :asc_nulls_first)
       #Ecto.Query<from u0 in "users", as: :user, order_by: [asc_nulls_first: u0.name]>
   """
-  @spec order_by(
-          Query.t(),
-          atom,
-          atom,
-          :asc | :asc_nulls_first | :asc_nulls_last | :desc | :desc_nulls_first | :desc_nulls_last
-        ) :: Query.t()
+  @spec order_by(Query.t(), atom, atom, order_directions) :: Query.t()
   def order_by(query, binding, field, direction),
     do: Query.from([{^binding, bd}] in query, order_by: [{^direction, field(bd, ^field)}])
 

--- a/test/ecto/dynamic_filters_test.exs
+++ b/test/ecto/dynamic_filters_test.exs
@@ -5,19 +5,18 @@ defmodule PhoenixApiToolkit.Ecto.DynamicFiltersTest do
   import PhoenixApiToolkit.Ecto.DynamicFilters
   import Ecto.Query
 
-  @main_binding :user
-  @literals ~w(id username residence address)a
-  @sets ~w(roles)a
-  @smaller_than_map %{
-    inserted_before: :inserted_at,
-    updated_before: :updated_at
-  }
-  @greater_than_or_equals_map %{
-    inserted_at_or_after: :inserted_at,
-    updated_at_or_after: :updated_at
-  }
-
-  def base_query, do: from(user in "users", as: :user)
+  @filter_definitions [
+    literals: [:id, :username, :residence, :address],
+    sets: [:roles],
+    smaller_than: [
+      inserted_before: :inserted_at,
+      updated_before: :updated_at
+    ],
+    greater_than_or_equals: [
+      inserted_at_or_after: :inserted_at,
+      updated_at_or_after: :updated_at
+    ]
+  ]
 
   def list_without_standard_filters(filters \\ %{}) do
     from(user in "users", as: :user)
@@ -37,28 +36,12 @@ defmodule PhoenixApiToolkit.Ecto.DynamicFiltersTest do
     from(user in query, where: ilike(user.username, ^"#{prefix}%"))
   end
 
-  def list_with_standard_filters_and_attributes(filters \\ %{}) do
+  def list_with_standard_filters(filters \\ %{}) do
     from(user in "users", as: :user)
     |> apply_filters(filters, fn
       # Add custom filters first and fallback to standard filters
       {:username_prefix, value}, query -> by_username_prefix(query, value)
-      filter, query -> standard_filters(query, filter)
-    end)
-  end
-
-  def list_with_standard_filters(filters \\ %{}) do
-    from(user in "users", as: :user)
-    |> apply_filters(filters, fn
-      filter, query ->
-        standard_filters(
-          query,
-          filter,
-          :user,
-          [:username],
-          [:roles],
-          @smaller_than_map,
-          @greater_than_or_equals_map
-        )
+      filter, query -> standard_filters(query, filter, :user, @filter_definitions)
     end)
   end
 


### PR DESCRIPTION
The code now generates a case-clause for each possible filter, without using guards. This should improve the pattern matching speed. Additionally, the API has been simplified and macro hygiene improved, from two macro's `standard_filters/2` (that relied on caller-context module attributes having been set) and `standard_filters/7` (that had too many mandatory parameters), to a single `standard_filters/4`. For example:

```Elixir
  @filter_definitions [
    literals: [:id, :username, :residence, :address],
    sets: [:roles],
    smaller_than_map: [
      inserted_before: :inserted_at,
      updated_before: :updated_at
    ],
    greater_than_or_equals_map: [
      inserted_at_or_after: :inserted_at,
      updated_at_or_after: :updated_at
    ]
  ]

  def list_with_standard_filters(filters \\ %{}) do
    from(user in "users", as: :user)
    |> apply_filters(filters, fn
      # Add custom filters first and fallback to standard filters
      {:username_prefix, value}, query -> by_username_prefix(query, value)
      filter, query -> standard_filters(query, filter, :user, @filter_definitions)
    end)
  end
```

Generates (**just for the standard_filters part**)

```Elixir
(
  query = query
  main_binding = @main_binding
  case(filter) do
    {:limit, value} ->
      GenericQueries.limit(query, value)
    {:offset, value} ->
      GenericQueries.offset(query, value)
    {:id, value} ->
      GenericQueries.equals(query, main_binding, :id, value)
    {:order_by, {:id, direction}} ->
      GenericQueries.order_by(query, main_binding, :id, direction)
    {:username, value} ->
      GenericQueries.equals(query, main_binding, :username, value)
    {:order_by, {:username, direction}} ->
      GenericQueries.order_by(query, main_binding, :username, direction)
    {:residence, value} ->
      GenericQueries.equals(query, main_binding, :residence, value)
    {:order_by, {:residence, direction}} ->
      GenericQueries.order_by(query, main_binding, :residence, direction)
    {:address, value} ->
      GenericQueries.equals(query, main_binding, :address, value)
    {:order_by, {:address, direction}} ->
      GenericQueries.order_by(query, main_binding, :address, direction)
    {:roles, value} ->
      GenericQueries.member_of(query, main_binding, :roles, value)
    {:inserted_before, value} ->
      GenericQueries.smaller_than(query, main_binding, :inserted_at, value)
    {:updated_before, value} ->
      GenericQueries.smaller_than(query, main_binding, :updated_at, value)
    {:inserted_at_or_after, value} ->
      GenericQueries.greater_than_or_equals(query, main_binding, :inserted_at, value)
    {:updated_at_or_after, value} ->
      GenericQueries.greater_than_or_equals(query, main_binding, :updated_at, value)
    _ ->
      query
  end
)
```