### PR TITLE
Add supported for multi-order_by, fix OTP 24 support

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -11,10 +11,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: Elixir ${{matrix.elixir}}
+    name: Elixir ${{matrix.elixir}} (OTP ${{matrix.otp}})
     strategy:
       matrix:
-        elixir: [1.7.x, 1.8.x, 1.9.x, 1.10.x, 1.11.x]
+        otp: [22.x]
+        elixir: [1.7.x, 1.10.x, 1.12.x]
+        include:
+          - otp: 24.x
+            elixir: 1.12.x
+          - otp: 21.x
+            elixir: 1.11.x
     env:
       MIX_ENV: test
     steps:
@@ -22,7 +28,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: erlef/setup-elixir@v1
         with:
-          otp-version: 22.x
+          otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
       - name: Cache
         uses: actions/cache@v2
@@ -30,9 +36,9 @@ jobs:
           path: |
             deps
             _build
-          key: cache-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          key: cache-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            cache-${{ matrix.elixir }}-
+            cache-${{ matrix.otp }}-${{ matrix.elixir }}-
       - name: Display build environment
         run: printenv
       - name: Install dependencies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,59 +1,59 @@
 version: "3"
 
 services:
-    phoenix_api_toolkit_1.10:
-        image: elixir:1.10-alpine
-        working_dir: /application
-        # The top mount mounts the local source code into the container for compilation and running.
-        # The other mounts effectively function as exclusions on the top mount, to prevent build artifacts from being created locally (as root).
-        # Some of the other mounts are mapped to docker volumes to improve build-on-build performance by caching the build artifacts.
-        # To completely clean the volumes, execute `docker-compose down -v` in a shell. A subsequent `docker-compose up` will run in a fresh environment.
-        volumes:
-            - .:/application:cached
-            - /application/.elixir_ls
-            - /application/cover
-            - 1.10__build:/application/_build
-            - 1.10_deps:/application/deps
-            - 1.10_mix:/root/.mix
-        environment:            
-            MIX_ENV: dev
-        command: /bin/sh /application/docker/cmd.sh
-    
-    phoenix_api_toolkit_1.9:
-        image: elixir:1.9-alpine
-        working_dir: /application
-        volumes:
-            - .:/application:cached
-            - /application/.elixir_ls
-            - /application/cover
-            - 1.9__build:/application/_build
-            - 1.9_deps:/application/deps
-            - 1.9_mix:/root/.mix
-        environment:            
-            MIX_ENV: dev
-        command: /bin/sh /application/docker/cmd.sh
+  phoenix_api_toolkit_1.12:
+    image: elixir:1.12-alpine
+    working_dir: /application
+    # The top mount mounts the local source code into the container for compilation and running.
+    # The other mounts effectively function as exclusions on the top mount, to prevent build artifacts from being created locally (as root).
+    # Some of the other mounts are mapped to docker volumes to improve build-on-build performance by caching the build artifacts.
+    # To completely clean the volumes, execute `docker-compose down -v` in a shell. A subsequent `docker-compose up` will run in a fresh environment.
+    volumes:
+      - .:/application:cached
+      - /application/.elixir_ls
+      - /application/cover
+      - 1.12__build:/application/_build
+      - 1.12_deps:/application/deps
+      - 1.12_mix:/root/.mix
+    environment:
+      MIX_ENV: dev
+    command: /bin/sh /application/docker/cmd.sh
 
-    phoenix_api_toolkit_1.7:
-        image: elixir:1.7-alpine
-        working_dir: /application
-        volumes:
-            - .:/application:cached
-            - /application/.elixir_ls
-            - /application/cover
-            - 1.7__build:/application/_build
-            - 1.7_deps:/application/deps
-            - 1.7_mix:/root/.mix
-        environment:            
-            MIX_ENV: dev
-        command: /bin/sh /application/docker/cmd.sh
+  phoenix_api_toolkit_1.10:
+    image: elixir:1.10-alpine
+    working_dir: /application
+    volumes:
+      - .:/application:cached
+      - /application/.elixir_ls
+      - /application/cover
+      - 1.10__build:/application/_build
+      - 1.10_deps:/application/deps
+      - 1.10_mix:/root/.mix
+    environment:
+      MIX_ENV: dev
+    command: /bin/sh /application/docker/cmd.sh
+
+  phoenix_api_toolkit_1.7:
+    image: elixir:1.7-alpine
+    working_dir: /application
+    volumes:
+      - .:/application:cached
+      - /application/.elixir_ls
+      - /application/cover
+      - 1.7__build:/application/_build
+      - 1.7_deps:/application/deps
+      - 1.7_mix:/root/.mix
+    environment:
+      MIX_ENV: dev
+    command: /bin/sh /application/docker/cmd.sh
 
 volumes:
-    1.10__build:
-    1.10_deps:
-    1.10_mix:
-    1.9__build:
-    1.9_deps:
-    1.9_mix:
-    1.7__build:
-    1.7_deps:
-    1.7_mix:
+  1.12__build:
+  1.12_deps:
+  1.12_mix:
+  1.10__build:
+  1.10_deps:
+  1.10_mix:
+  1.7__build:
+  1.7_deps:
+  1.7_mix:

--- a/lib/internal.ex
+++ b/lib/internal.ex
@@ -16,4 +16,14 @@ defmodule PhoenixApiToolkit.Internal do
   def parse_order_by(fld, def_bnd, aliases) do
     parse_order_by({:asc, fld}, def_bnd, aliases)
   end
+
+  # OTP 22 introduced a new crypto API, and the old one is hard deprecated in OTP 24
+  # we differentiate between the two at compile time
+  if :erlang.system_info(:otp_release) |> to_string() |> String.to_integer() < 22 do
+    @doc false
+    def hmac(alg, secret, body), do: :crypto.hmac(alg, secret, body)
+  else
+    @doc false
+    def hmac(alg, secret, body), do: :crypto.mac(:hmac, alg, secret, body)
+  end
 end

--- a/lib/security/hmac_plug.ex
+++ b/lib/security/hmac_plug.ex
@@ -1,7 +1,7 @@
 defmodule PhoenixApiToolkit.Security.HmacPlug do
   @moduledoc """
   Checks HMAC authentication. Expects a HMAC-<some_algorithm> of the request body to be present in the
-  "authorization" header. Supported algorithms are those supported by `:crypto.hmac/3`.
+  "authorization" header. Supported algorithms are those supported by `:crypto.mac/4`.
   Relies on `PhoenixApiToolkit.CacheBodyReader` being called by `Plug.Parsers`.
 
   To be considered a valid request by the plug, a request has to meet the following criteria:
@@ -71,6 +71,7 @@ defmodule PhoenixApiToolkit.Security.HmacPlug do
   import Plug.Conn
   alias PhoenixApiToolkit.Security.HmacVerificationError
   alias PhoenixApiToolkit.CacheBodyReader
+  alias PhoenixApiToolkit.Internal
   require Logger
 
   @doc false
@@ -94,7 +95,7 @@ defmodule PhoenixApiToolkit.Security.HmacPlug do
 
     with hmac <- parse_auth_header(conn),
          body = CacheBodyReader.get_raw_request_body(conn) || "",
-         message_hmac = :crypto.hmac(hash_algorithm, hmac_secret, body) |> Base.encode64(),
+         message_hmac = Internal.hmac(hash_algorithm, hmac_secret, body) |> Base.encode64(),
          {:hmac_matches, true} <- {:hmac_matches, hmac == message_hmac},
          :ok <- verify_method(conn),
          :ok <- verify_path(conn),

--- a/lib/test_helpers.ex
+++ b/lib/test_helpers.ex
@@ -3,6 +3,7 @@ defmodule PhoenixApiToolkit.TestHelpers do
   Various helper functions for writing tests.
   """
   alias Plug.Conn
+  alias PhoenixApiToolkit.Internal
   require Logger
 
   if Code.ensure_loaded?(:jose) do
@@ -191,7 +192,7 @@ defmodule PhoenixApiToolkit.TestHelpers do
     conn
     |> Conn.put_req_header(
       "authorization",
-      :crypto.hmac(:sha256, secret, body) |> Base.encode64()
+      Internal.hmac(:sha256, secret, body) |> Base.encode64()
     )
   end
 


### PR DESCRIPTION
This allows us to support nested sorting through query parameters, for example `/api/things?order_by=desc:name,asc:date`.

Also, I noticed that OTP 24 hard-deprecated the `:crypto:hmac/3` function (in favor of the new OTP22+ crypto API), so I've added a compile-time check for the OTP version so that OTP < 22 uses the old API and everything else uses the new one. The CI matrix now adds a Elixir 1.12/OTP24 job and a Elixir 1.11/OTP21 job to verify both edge cases.