### PR TITLE
Use Plug.Crypto.secure_compare/2 to avoid timing attacks

### DIFF
--- a/lib/security/hmac_plug.ex
+++ b/lib/security/hmac_plug.ex
@@ -96,7 +96,7 @@ defmodule PhoenixApiToolkit.Security.HmacPlug do
     with hmac <- parse_auth_header(conn),
          body = CacheBodyReader.get_raw_request_body(conn) || "",
          message_hmac = Internal.hmac(hash_algorithm, hmac_secret, body) |> Base.encode64(),
-         {:hmac_matches, true} <- {:hmac_matches, hmac == message_hmac},
+         {:hmac_matches, true} <- {:hmac_matches, Plug.Crypto.secure_compare(hmac, message_hmac)},
          :ok <- verify_method(conn),
          :ok <- verify_path(conn),
          :ok <- verify_timestamp(conn, max_age) do


### PR DESCRIPTION
I was looking through your repo (super helpful!) and saw that your equality comparison is susceptible to [timing attacks](http://codahale.com/a-lesson-in-timing-attacks/). [Plug.Crypto.secure_compare/2](https://hexdocs.pm/plug_crypto/Plug.Crypto.html#secure_compare/2) is probably what you want here.