### PR TITLE
Fix/correct limit and offset when joining

### DIFF
--- a/lib/ecto/dynamic_filters.ex
+++ b/lib/ecto/dynamic_filters.ex
@@ -616,8 +616,7 @@ defmodule PhoenixApiToolkit.Ecto.DynamicFilters do
         |> distinct(:id)
         |> exclude(:preload)
 
-      from [p] in unquote(query),
-        join: sel in subquery(fq), on: sel.id == p.id
+      from([p] in unquote(query), join: sel in subquery(fq), on: sel.id == p.id)
     end
   end
 

--- a/lib/ecto/dynamic_filters.ex
+++ b/lib/ecto/dynamic_filters.ex
@@ -132,7 +132,7 @@ defmodule PhoenixApiToolkit.Ecto.DynamicFilters do
 
       # let's do some filtering
       iex> list_with_standard_filters(%{username: "Peter", balance_lt: 50.00, address: "sesame street"})
-      #Ecto.Query<from u0 in "users", as: :user, where: u0.address == ^"sesame street", where: u0.username == ^"Peter", where: u0.balance < ^50.0>
+      #Ecto.Query<from u0 in "users", as: :user, where: u0.address == ^"sesame street", where: u0.balance < ^50.0, where: u0.username == ^"Peter">
 
       # associations can be dynamically joined into the query, only when necessary
       iex> list_with_standard_filters(%{role_name: "admin"})
@@ -187,7 +187,7 @@ defmodule PhoenixApiToolkit.Ecto.DynamicFilters do
       iex> list_with_standard_filters(%{roles: "admin"})
       #Ecto.Query<from u0 in "users", as: :user, where: fragment("? && ?", u0.roles, ^["admin"])>
       iex> list_with_standard_filters(%{roles: ["admin", "superadmin"], all_roles: ["creator", "user"]})
-      #Ecto.Query<from u0 in "users", as: :user, where: fragment("? && ?", u0.roles, ^["admin", "superadmin"]), where: fragment("? @> ?", u0.roles, ^["creator", "user"])>
+      #Ecto.Query<from u0 in "users", as: :user, where: fragment("? @> ?", u0.roles, ^["creator", "user"]), where: fragment("? && ?", u0.roles, ^["admin", "superadmin"])>
 
       # you can order by multiple fields and specify bindings
       iex> list_with_standard_filters(%{"balance" => 12, "order_by" => [asc: {:user, :username}, desc: :role]})

--- a/lib/ecto/dynamic_filters.ex
+++ b/lib/ecto/dynamic_filters.ex
@@ -626,13 +626,13 @@ defmodule PhoenixApiToolkit.Ecto.DynamicFilters do
     end
   end
 
-  def maybe_use_subquery(fq, query) when fq.joins != [] and (fq.limit != nil or fq.offset != nil) do
+  def maybe_use_subquery(fq, query)
+      when fq.joins != [] and (fq.limit != nil or fq.offset != nil) do
     fq = fq |> distinct(:id) |> exclude(:preload)
     from([p] in query, inner_join: sel in subquery(fq), on: sel.id == p.id)
   end
 
   def maybe_use_subquery(fq, _query), do: fq
-
 
   @doc """
   Generate a markdown docstring from filter definitions, as passed to `standard_filters/6`,

--- a/lib/ecto/dynamic_filters.ex
+++ b/lib/ecto/dynamic_filters.ex
@@ -123,7 +123,7 @@ defmodule PhoenixApiToolkit.Ecto.DynamicFilters do
         |> standard_filters filters, :user, @filter_definitions, &resolve_binding/2 do
           # Add custom filters first and fall back to standard filters
           {:group_name, value}, query -> by_group_name(query, value)
-        end)
+        end
       end
 
       # filtering is optional

--- a/lib/ecto/dynamic_filters.ex
+++ b/lib/ecto/dynamic_filters.ex
@@ -616,7 +616,7 @@ defmodule PhoenixApiToolkit.Ecto.DynamicFilters do
         |> distinct(:id)
         |> exclude(:preload)
 
-      from([p] in unquote(query), join: sel in subquery(fq), on: sel.id == p.id)
+      from [p] in unquote(query), join: sel in subquery(fq), on: sel.id == p.id, where: !is_nil(sel.id)
     end
   end
 

--- a/lib/ecto/dynamic_filters.ex
+++ b/lib/ecto/dynamic_filters.ex
@@ -608,7 +608,16 @@ defmodule PhoenixApiToolkit.Ecto.DynamicFilters do
     function_statement = {:fn, [], clauses}
 
     quote do
-      Enum.reduce(unquote(filters), unquote(query), unquote(function_statement))
+      # By filtering separately from the retrieval of the rows,
+      # we avoid limit and offset from being affected by additional rows created by joins
+
+      fq =
+        Enum.reduce(unquote(filters), unquote(query), unquote(function_statement))
+        |> distinct(:id)
+        |> exclude(:preload)
+
+      from [p] in unquote(query),
+        join: sel in subquery(fq), on: sel.id == p.id
     end
   end
 

--- a/lib/ecto/dynamic_filters.ex
+++ b/lib/ecto/dynamic_filters.ex
@@ -132,7 +132,7 @@ defmodule PhoenixApiToolkit.Ecto.DynamicFilters do
 
       # let's do some filtering
       iex> list_with_standard_filters(%{username: "Peter", balance_lt: 50.00, address: "sesame street"})
-      #Ecto.Query<from u0 in "users", as: :user, where: u0.address == ^"sesame street", where: u0.balance < ^50.0, where: u0.username == ^"Peter">
+      #Ecto.Query<from u0 in "users", as: :user, where: u0.address == ^"sesame street", where: u0.username == ^"Peter", where: u0.balance < ^50.0>
 
       # associations can be dynamically joined into the query, only when necessary
       iex> list_with_standard_filters(%{role_name: "admin"})
@@ -141,6 +141,17 @@ defmodule PhoenixApiToolkit.Ecto.DynamicFilters do
       # limit, offset, and order_by are supported
       iex> list_with_standard_filters(%{"limit" => 10, offset: 1, order_by: [desc: :address]})
       #Ecto.Query<from u0 in "users", as: :user, order_by: [desc: u0.address], limit: ^10, offset: ^1>
+
+      # when joins and limit/offset are combined, a subquery is used to prevent row inflation
+      iex> list_with_standard_filters(%{role_name: "admin", limit: 10})
+      #Ecto.Query<from u0 in "users", as: :user, join: u1 in subquery(from u0 in "users",
+        as: :user,
+        left_join: r1 in "roles",
+        as: :role,
+        on: true,
+        where: r1.name == ^"admin",
+        limit: ^10,
+        distinct: [asc: u0.id]), on: u1.id == u0.id>
 
       # order_by can use association fields as well, which are dynamically joined in that case
       iex> list_with_standard_filters(%{order_by: [asc: {:role, :name}]})
@@ -176,7 +187,7 @@ defmodule PhoenixApiToolkit.Ecto.DynamicFilters do
       iex> list_with_standard_filters(%{roles: "admin"})
       #Ecto.Query<from u0 in "users", as: :user, where: fragment("? && ?", u0.roles, ^["admin"])>
       iex> list_with_standard_filters(%{roles: ["admin", "superadmin"], all_roles: ["creator", "user"]})
-      #Ecto.Query<from u0 in "users", as: :user, where: fragment("? @> ?", u0.roles, ^["creator", "user"]), where: fragment("? && ?", u0.roles, ^["admin", "superadmin"])>
+      #Ecto.Query<from u0 in "users", as: :user, where: fragment("? && ?", u0.roles, ^["admin", "superadmin"]), where: fragment("? @> ?", u0.roles, ^["creator", "user"])>
 
       # you can order by multiple fields and specify bindings
       iex> list_with_standard_filters(%{"balance" => 12, "order_by" => [asc: {:user, :username}, desc: :role]})
@@ -608,17 +619,20 @@ defmodule PhoenixApiToolkit.Ecto.DynamicFilters do
     function_statement = {:fn, [], clauses}
 
     quote do
-      # By filtering separately from the retrieval of the rows,
-      # we avoid limit and offset from being affected by additional rows created by joins
+      unquoted_query = unquote(query)
+      fq = Enum.reduce(unquote(filters), unquoted_query, unquote(function_statement))
 
-      fq =
-        Enum.reduce(unquote(filters), unquote(query), unquote(function_statement))
-        |> distinct(:id)
-        |> exclude(:preload)
-
-      from [p] in unquote(query), join: sel in subquery(fq), on: sel.id == p.id, where: !is_nil(sel.id)
+      PhoenixApiToolkit.Ecto.DynamicFilters.maybe_use_subquery(fq, unquoted_query)
     end
   end
+
+  def maybe_use_subquery(fq, query) when fq.joins != [] and (fq.limit != nil or fq.offset != nil) do
+    fq = fq |> distinct(:id) |> exclude(:preload)
+    from([p] in query, inner_join: sel in subquery(fq), on: sel.id == p.id)
+  end
+
+  def maybe_use_subquery(fq, _query), do: fq
+
 
   @doc """
   Generate a markdown docstring from filter definitions, as passed to `standard_filters/6`,


### PR DESCRIPTION
Fixes the problem where joined rows were counted towards the limit and offset, causing less rows to be returned than expected

This is a breaking change in that we use distinct causing errors when queries built using standard_filters already use distinct. I think in most cases this can be easily fixed by removing the existing distinct (`Ecto.Query.exclude(:distinct)`)
